### PR TITLE
:memo: Fix configuration attribute name

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ By default, the wrap-guide is placed at the 80th column.
 You can customize where the column is placed using the following config option:
 
 ```coffeescript
-"wrap-guide":
+"wrapGuide":
   columns: [
     { pattern: "\.mm$", column: 200 }
     { pattern: "\.cc$", column: 120 }


### PR DESCRIPTION
Update the docs to use the correct [attribute name](https://github.com/atom/wrap-guide/blob/12d45c283b91cb0cece32de8520a6a231de8c064/lib/wrap-guide-view.coffee#L23) (i.e., `wrapGuide` instead of `wrap-guide`).
