### PR TITLE
Add the ability to customize by grammar scope name

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,12 +16,14 @@ You can customize where the column is placed using the following config option:
   columns: [
     { pattern: '\.mm$', column: 200 }
     { pattern: '\.cc$', column: 120 }
+    { scope: 'source.gfm', column: -1 }
   ]
 ```
 
 The above config example would place the guide at the 200th column for paths
-that end with `.mm` and place the guide at the 120th column for paths that end
-with `.cc`.
+that end with `.mm`, place the guide at the 120th column for paths that end
+with `.cc` and hide the guide for files that use the GitHub-Flavored Markdown
+grammar.
 
 You can configure the color and/or width of the line by adding the following
 CSS/LESS to a custom stylesheet:

--- a/lib/wrap-guide-view.coffee
+++ b/lib/wrap-guide-view.coffee
@@ -23,21 +23,25 @@ class WrapGuideView extends View
   getDefaultColumn: ->
     atom.config.getPositiveInt('editor.preferredLineLength', 80)
 
-  getGuideColumn: (path) ->
+  getGuideColumn: (path, scopeName) ->
     customColumns = atom.config.get('wrap-guide.columns')
     return @getDefaultColumn() unless Array.isArray(customColumns)
     for customColumn in customColumns when typeof customColumn is 'object'
-      {pattern, column} = customColumn
-      continue unless pattern
-      try
-        regex = new RegExp(pattern)
-      catch
-        continue
-      return parseInt(column) if regex.test(path)
+      {pattern, scope, column} = customColumn
+      continue unless pattern or scope
+      if pattern
+        try
+          regex = new RegExp(pattern)
+        catch
+          continue
+        return parseInt(column) if regex.test(path)
+      else
+        return parseInt(column) if scope is scopeName
     @getDefaultColumn()
 
   updateGuide: ->
-    column = @getGuideColumn(@editorView.getEditor().getPath())
+    editor = @editorView.getEditor()
+    column = @getGuideColumn(editor.getPath(), editor.getGrammar().scopeName)
     if column > 0
       columnWidth = @editorView.charWidth * column
       if columnWidth < @editorView.layerMinWidth or columnWidth < @editorView.width()


### PR DESCRIPTION
Adds the ability to customize the wrap guide position and visibility by the grammar's scope name. This allows one to easily customize the wrap guide for all Ruby files without having to duplicate all of the logic for recognizing a Ruby file from the Ruby grammar, for example.
