### PR TITLE
Fix styling example in README to apply within shadow DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It is possible to configure the color and/or width of the line by adding the
 following CSS/LESS to your `styles.less`:
 
 ```css
-.wrap-guide {
+atom-text-editor::shadow .wrap-guide {
   width: 10px;
   background-color: red;
 }


### PR DESCRIPTION
Fixes https://github.com/atom/wrap-guide/issues/29. I think the example in the README should work in the latest version of Atom, and with default config settings (= shadow DOM turned on).

There's also https://github.com/atom/docs/issues/56, but that's related to improving the docs site so that examples from the docs work with the shadow DOM.

cc @benogle for :eyes: and :memo: 