### PR TITLE
Relativize wrap guide position

### DIFF
--- a/lib/wrap-guide-element.coffee
+++ b/lib/wrap-guide-element.coffee
@@ -24,7 +24,7 @@ class WrapGuideElement extends HTMLDivElement
       setTimeout(updateGuideCallback, 0)
 
     # FIXME: remove conditional as soon as the tiled editor is released.
-    if atom.hasTiledEditor
+    if @editorElement.hasTiledRendering
       subscriptions.add @editor.onDidChangeScrollLeft(updateGuideCallback)
 
     subscriptions.add @editor.onDidChangePath(updateGuideCallback)
@@ -83,7 +83,7 @@ class WrapGuideElement extends HTMLDivElement
     if column > 0 and @isEnabled()
       columnWidth = @editorElement.getDefaultCharacterWidth() * column
       # FIXME: remove conditional as soon as the tiled editor is released.
-      columnWidth -= @editor.getScrollLeft() if atom.hasTiledEditor
+      columnWidth -= @editor.getScrollLeft() if @editorElement.hasTiledRendering
       @style.left = "#{columnWidth}px"
       @style.display = 'block'
     else

--- a/lib/wrap-guide-element.coffee
+++ b/lib/wrap-guide-element.coffee
@@ -23,7 +23,10 @@ class WrapGuideElement extends HTMLDivElement
       # setTimeout because we need to wait for the editor measurement to happen
       setTimeout(updateGuideCallback, 0)
 
-    subscriptions.add @editor.onDidChangeScrollLeft(updateGuideCallback)
+    # FIXME: remove conditional as soon as the tiled editor is released.
+    if atom.hasTiledEditor
+      subscriptions.add @editor.onDidChangeScrollLeft(updateGuideCallback)
+
     subscriptions.add @editor.onDidChangePath(updateGuideCallback)
     subscriptions.add @editor.onDidChangeGrammar =>
       configSubscriptions.dispose()
@@ -79,7 +82,8 @@ class WrapGuideElement extends HTMLDivElement
     column = @getGuideColumn(@editor.getPath(), @editor.getGrammar().scopeName)
     if column > 0 and @isEnabled()
       columnWidth = @editorElement.getDefaultCharacterWidth() * column
-      columnWidth -= @editor.getScrollLeft()
+      # FIXME: remove conditional as soon as the tiled editor is released.
+      columnWidth -= @editor.getScrollLeft() if atom.hasTiledEditor
       @style.left = "#{columnWidth}px"
       @style.display = 'block'
     else

--- a/lib/wrap-guide-element.coffee
+++ b/lib/wrap-guide-element.coffee
@@ -23,6 +23,7 @@ class WrapGuideElement extends HTMLDivElement
       # setTimeout because we need to wait for the editor measurement to happen
       setTimeout(updateGuideCallback, 0)
 
+    subscriptions.add @editor.onDidChangeScrollLeft(updateGuideCallback)
     subscriptions.add @editor.onDidChangePath(updateGuideCallback)
     subscriptions.add @editor.onDidChangeGrammar =>
       configSubscriptions.dispose()
@@ -78,6 +79,7 @@ class WrapGuideElement extends HTMLDivElement
     column = @getGuideColumn(@editor.getPath(), @editor.getGrammar().scopeName)
     if column > 0 and @isEnabled()
       columnWidth = @editorElement.getDefaultCharacterWidth() * column
+      columnWidth -= @editor.getScrollLeft()
       @style.left = "#{columnWidth}px"
       @style.display = 'block'
     else

--- a/spec/wrap-guide-spec.coffee
+++ b/spec/wrap-guide-spec.coffee
@@ -78,6 +78,19 @@ describe "WrapGuide", ->
       expect(getLeftPosition(wrapGuide)).toBeLessThan(initial)
       expect(wrapGuide).toBeVisible()
 
+  describe "when the editor's scroll left changes", ->
+    it "updates the wrap guide position to a relative position on screen", ->
+      editor.setText("a long line which causes the editor to scroll")
+      editor.setWidth(100)
+
+      initial = getLeftPosition(wrapGuide)
+      expect(initial).toBeGreaterThan(0)
+
+      editor.setScrollLeft(10)
+
+      expect(getLeftPosition(wrapGuide)).toBe(initial - 10)
+      expect(wrapGuide).toBeVisible()
+
   describe "when the editor's grammar changes", ->
     it "updates the wrap guide position", ->
       atom.config.set('editor.preferredLineLength', 20, scopeSelector: '.source.js')

--- a/spec/wrap-guide-spec.coffee
+++ b/spec/wrap-guide-spec.coffee
@@ -1,7 +1,7 @@
 Grim = require 'grim'
 
 describe "WrapGuide", ->
-  [editor, wrapGuide, workspaceElement] = []
+  [editor, editorElement, wrapGuide, workspaceElement] = []
 
   getLeftPosition = (element) ->
     parseInt(element.style.left)
@@ -27,7 +27,8 @@ describe "WrapGuide", ->
 
     runs ->
       editor = atom.workspace.getActiveTextEditor()
-      wrapGuide = atom.views.getView(editor).rootElement.querySelector(".wrap-guide")
+      editorElement = atom.views.getView(editor)
+      wrapGuide = editorElement.rootElement.querySelector(".wrap-guide")
 
   describe ".activate", ->
     getWrapGuides  = ->
@@ -78,20 +79,21 @@ describe "WrapGuide", ->
       expect(getLeftPosition(wrapGuide)).toBeLessThan(initial)
       expect(wrapGuide).toBeVisible()
 
-  # FIXME: remove conditional as soon as the tiled editor is released.
-  if atom.hasTiledEditor
-    describe "when the editor's scroll left changes", ->
-      it "updates the wrap guide position to a relative position on screen", ->
-        editor.setText("a long line which causes the editor to scroll")
-        editor.setWidth(100)
+  describe "when the editor's scroll left changes", ->
+    it "updates the wrap guide position to a relative position on screen", ->
+      # FIXME: remove conditional as soon as the tiled editor is released.
+      return unless editorElement.hasTiledRendering
 
-        initial = getLeftPosition(wrapGuide)
-        expect(initial).toBeGreaterThan(0)
+      editor.setText("a long line which causes the editor to scroll")
+      editor.setWidth(100)
 
-        editor.setScrollLeft(10)
+      initial = getLeftPosition(wrapGuide)
+      expect(initial).toBeGreaterThan(0)
 
-        expect(getLeftPosition(wrapGuide)).toBe(initial - 10)
-        expect(wrapGuide).toBeVisible()
+      editor.setScrollLeft(10)
+
+      expect(getLeftPosition(wrapGuide)).toBe(initial - 10)
+      expect(wrapGuide).toBeVisible()
 
   describe "when the editor's grammar changes", ->
     it "updates the wrap guide position", ->

--- a/spec/wrap-guide-spec.coffee
+++ b/spec/wrap-guide-spec.coffee
@@ -78,18 +78,20 @@ describe "WrapGuide", ->
       expect(getLeftPosition(wrapGuide)).toBeLessThan(initial)
       expect(wrapGuide).toBeVisible()
 
-  describe "when the editor's scroll left changes", ->
-    it "updates the wrap guide position to a relative position on screen", ->
-      editor.setText("a long line which causes the editor to scroll")
-      editor.setWidth(100)
+  # FIXME: remove conditional as soon as the tiled editor is released.
+  if atom.hasTiledEditor
+    describe "when the editor's scroll left changes", ->
+      it "updates the wrap guide position to a relative position on screen", ->
+        editor.setText("a long line which causes the editor to scroll")
+        editor.setWidth(100)
 
-      initial = getLeftPosition(wrapGuide)
-      expect(initial).toBeGreaterThan(0)
+        initial = getLeftPosition(wrapGuide)
+        expect(initial).toBeGreaterThan(0)
 
-      editor.setScrollLeft(10)
+        editor.setScrollLeft(10)
 
-      expect(getLeftPosition(wrapGuide)).toBe(initial - 10)
-      expect(wrapGuide).toBeVisible()
+        expect(getLeftPosition(wrapGuide)).toBe(initial - 10)
+        expect(wrapGuide).toBeVisible()
 
   describe "when the editor's grammar changes", ->
     it "updates the wrap guide position", ->


### PR DESCRIPTION
This change is needed in order to support the new tiled editor. You can find further information about this on https://github.com/atom/atom/pull/6733, but basically we don’t use absolute coordinates to position lines on screen anymore.

Indeed, this is the situation if we use wrap-guide with the tiled editor, and we scroll left/right (please, notice how the guide sticks to a fixed position without being affected by scrolling):

![before](https://cloud.githubusercontent.com/assets/482957/7783041/5427f56e-0133-11e5-85eb-b9f872141251.gif)

And this is a screenshot after the proposed fix:

![after](https://cloud.githubusercontent.com/assets/482957/7783040/5424b8ae-0133-11e5-976f-a049a7593fae.gif)

This should be released as soon as https://github.com/atom/atom/pull/6733 is released. As @benogle once said: 

> You know the wrap-guide has to work. Muy importante.

:smile_cat: 

/cc: @nathansobo @atom/feedback