### PR TITLE
Changing z-index so that cursor is not hidden under wrap-guide

### DIFF
--- a/styles/wrap-guide.less
+++ b/styles/wrap-guide.less
@@ -4,7 +4,7 @@ atom-text-editor::shadow {
   .wrap-guide {
     height: 100%;
     width: 1px;
-    z-index: 100;
+    z-index: 3;
     position: absolute;
     top: 0;
     background-color: @syntax-wrap-guide-color;


### PR DESCRIPTION
# Problem

for some syntax themes like [base16-tomorrow](https://github.com/atom/base16-tomorrow-dark-theme) it becomes apparent that the wrap-guide has a higher z-index than the cursor. More specific:

* The atom cursor is at ```z-index: 4``` [(see code)](https://github.com/atom/atom/blob/29ab1af2bf60afdea2734d76ec5e4a82a36bc221/static/text-editor-shadow.less#L147)
   whereas
* wrap guide has ```z-index: 100```

This results in the cursor being hidden under the wrap guide which is demoed here:
![hidden_cursor](https://cloud.githubusercontent.com/assets/72940/8648103/281043b6-295e-11e5-8169-298b85f2da78.gif)

# Solution

changing the z-index to a value lower than 4