### PR TITLE
Introduce simple tooltip

### DIFF
--- a/lib/wrap-guide-element.coffee
+++ b/lib/wrap-guide-element.coffee
@@ -91,7 +91,7 @@ class WrapGuideElement extends HTMLDivElement
       @style.display = 'none'
 
   setTooltip: ->
-    @title = "This is the wrap guide."
+    @title = "This line is the wrap-guide. You can quickly toggle it via the command palette."
 
 module.exports =
 document.registerElement('wrap-guide',

--- a/lib/wrap-guide-element.coffee
+++ b/lib/wrap-guide-element.coffee
@@ -91,7 +91,7 @@ class WrapGuideElement extends HTMLDivElement
       @style.display = 'none'
 
   setTooltip: ->
-    @title = "This line is the wrap-guide. You can quickly toggle it via the command palette."
+    @title = "This line is the wrap-guide. You can quickly toggle it via the View menu."
 
 module.exports =
 document.registerElement('wrap-guide',

--- a/lib/wrap-guide-element.coffee
+++ b/lib/wrap-guide-element.coffee
@@ -6,6 +6,7 @@ class WrapGuideElement extends HTMLDivElement
     @attachToLines()
     @handleEvents()
     @updateGuide()
+    @setTooltip()
 
     this
 
@@ -88,6 +89,9 @@ class WrapGuideElement extends HTMLDivElement
       @style.display = 'block'
     else
       @style.display = 'none'
+
+  setTooltip: ->
+    @title = "This is the wrap guide."
 
 module.exports =
 document.registerElement('wrap-guide',

--- a/spec/wrap-guide-spec.coffee
+++ b/spec/wrap-guide-spec.coffee
@@ -58,7 +58,7 @@ describe "WrapGuide", ->
     it "adds a tooltip to the wrap guide", ->
       tooltipBody = wrapGuide.title
       expect(tooltipBody).toBe "This line is the wrap-guide. You can quickly toggle it via the
-        command palette."
+        View menu."
 
   describe "when the font size changes", ->
     it "updates the wrap guide position", ->

--- a/spec/wrap-guide-spec.coffee
+++ b/spec/wrap-guide-spec.coffee
@@ -55,6 +55,11 @@ describe "WrapGuide", ->
       expect(getLeftPosition(wrapGuide)).toBe(width)
       expect(wrapGuide).toBeVisible()
 
+    it "adds a tooltip to the wrap guide", ->
+      tooltipBody = wrapGuide.title
+      expect(tooltipBody).toBe "This line is the wrap-guide. You can quickly toggle it via the
+        command palette."
+
   describe "when the font size changes", ->
     it "updates the wrap guide position", ->
       initial = getLeftPosition(wrapGuide)

--- a/styles/wrap-guide.less
+++ b/styles/wrap-guide.less
@@ -3,10 +3,22 @@
 atom-text-editor::shadow {
   .wrap-guide {
     height: 100%;
-    width: 1px;
+    width: 5px;
     z-index: 3;
     position: absolute;
     top: 0;
-    background-color: @syntax-wrap-guide-color;
+    background-color: transparent;
+    margin-left: -2px;
+
+    &:after {
+      content: "";
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      left: 2px;
+      box-sizing: border-box;
+      border-left: 1px solid @syntax-wrap-guide-color;
+    }
   }
 }


### PR DESCRIPTION
In order to make it easier to "hit" the wrap guide region in order to display the tooltip, I made the element wider, and pushed the actual line into an `:after` pseudo-element. Instead of the original `1px` width, the wrap guide is now `5px` wide. I think that should be sufficient.

:rotating_light: Do not merge this before merging #39. :rotating_light: 

/cc @atom/feedback 
