### PR TITLE
Switch from solid to dotted line

### DIFF
--- a/styles/wrap-guide.less
+++ b/styles/wrap-guide.less
@@ -7,6 +7,15 @@ atom-text-editor::shadow {
     z-index: 3;
     position: absolute;
     top: 0;
-    background-color: @syntax-wrap-guide-color;
+    background-color: transparent;
+
+    &:after {
+      content: "";
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      box-sizing: border-box;
+      border-left: 1px dotted @syntax-wrap-guide-color;
+    }
   }
 }


### PR DESCRIPTION
This PR changes the visual representation of the wrap guide from a solid line to a dotted line. The change is very subtle, but hopefully enough to make it easier for new users to figure out that the wrap guide is not a visual artifact/glitch, but an actual feature. Likely extra effective when coupled with #37.

Before:
<img width="275" alt="before" src="https://cloud.githubusercontent.com/assets/3622/8860575/124e8310-3185-11e5-9124-bf444b0d4449.png">

After:
<img width="275" alt="after" src="https://cloud.githubusercontent.com/assets/3622/8860582/18dcd402-3185-11e5-8717-6452936193da.png">
