### PR TITLE
Add toggle command

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,14 +1,26 @@
+{CompositeDisposable} = require 'atom'
 Grim = require 'grim'
 
 WrapGuideElement = require './wrap-guide-element'
 
 module.exports =
+  config:
+    enabled:
+      type: 'boolean'
+      default: true
+
   activate: ->
     @updateConfiguration()
 
     atom.workspace.observeTextEditors (editor) ->
       editorElement = atom.views.getView(editor)
       wrapGuideElement = new WrapGuideElement().initialize(editor, editorElement)
+
+    @subscriptions = new CompositeDisposable
+    @subscriptions.add atom.commands.add 'atom-workspace', 'wrap-guide:toggle': => @toggle()
+
+  deactivate: ->
+    @subscriptions.dispose()
 
   updateConfiguration: ->
     customColumns = atom.config.get('wrap-guide.columns')
@@ -32,3 +44,7 @@ module.exports =
 
     newColumns = undefined if newColumns.length is 0
     atom.config.set('wrap-guide.columns', newColumns)
+
+  toggle: ->
+    currentState = atom.config.get('wrap-guide.enabled')
+    atom.config.set('wrap-guide.enabled', not currentState)

--- a/menus/wrap-guide.cson
+++ b/menus/wrap-guide.cson
@@ -1,0 +1,7 @@
+'menu': [
+  'label': 'View'
+  'submenu': [
+    'label': 'Toggle Wrap Guide'
+    'command': 'wrap-guide:toggle'
+  ]
+]

--- a/spec/wrap-guide-spec.coffee
+++ b/spec/wrap-guide-spec.coffee
@@ -188,3 +188,20 @@ describe "WrapGuide", ->
       atom.config.set('wrap-guide.enabled', false, scopeSelector: '.source.js')
 
       expect(wrapGuide).not.toBeVisible()
+
+  describe "toogle command", ->
+    it "hides the guide when it was initially enabled and visible", ->
+      atom.config.set('wrap-guide.enabled', true)
+      expect(wrapGuide).toBeVisible()
+
+      atom.commands.dispatch(workspaceElement, 'wrap-guide:toggle')
+      expect(wrapGuide).toBeHidden()
+      expect(atom.config.get('wrap-guide.enabled')).toBe false
+
+    it "shows the guide when it was initially disabled and not visible", ->
+      atom.config.set('wrap-guide.enabled', false)
+      expect(wrapGuide).toBeHidden()
+
+      atom.commands.dispatch(workspaceElement, 'wrap-guide:toggle')
+      expect(wrapGuide).toBeVisible()
+      expect(atom.config.get('wrap-guide.enabled')).toBe true


### PR DESCRIPTION
:warning: This PR is still work in progress as it contains no specs. And it definitely needs some... :warning:

Closes https://github.com/atom/wrap-guide/issues/28

Wrap guide already had basic support for enabling/disabling, but it was only exposed on a scope level. Hence I first added/exposed package configuration option `wrap-guide.enabled` so that the wrap guide can be disabled globally via config (it could in the past as well, it just wasn't obvious that you could). As the title eludes to, I've also added a `toggle` command for "flipping" the state of the `enabled` setting.

I haven't verified this, but given how the config stuff works with scope cascading, I'm pretty sure it's possible to still disable the wrap guide globally, yet enable it for individual scopes. This is something that should be verified by specs.
