### PR TITLE
Give wrap-guide its own layer

### DIFF
--- a/styles/wrap-guide.less
+++ b/styles/wrap-guide.less
@@ -8,5 +8,6 @@ atom-text-editor::shadow {
     position: absolute;
     top: 0;
     background-color: @syntax-wrap-guide-color;
+    -webkit-transform: translateZ(0);
   }
 }


### PR DESCRIPTION
While scrolling I noticed that the `.lines` layer was being partially repainted a lot of times. Namely, this was the effect I was observing:

![lines-paint](https://cloud.githubusercontent.com/assets/482957/9496746/275b9b88-4c12-11e5-8d3a-4f5822e33586.gif)

The problem was caused by how Chrome organized layers to paint the wrap-guide. Since tiles are destroyed as we scroll, those layers had to be reorganized each time a tile was removed.  By giving the wrap-guide its own layer we prevent this issue from happening again:

![after](https://cloud.githubusercontent.com/assets/482957/9496785/575aa996-4c12-11e5-863b-3b7b39ac049e.gif)

/cc: @atom/feedback 
