### PR TITLE
Adapt specs to work with the logical DisplayBuffer

### DIFF
--- a/spec/wrap-guide-spec.coffee
+++ b/spec/wrap-guide-spec.coffee
@@ -85,13 +85,13 @@ describe "WrapGuide", ->
       return unless editorElement.hasTiledRendering
 
       editor.setText("a long line which causes the editor to scroll")
-      editor.setWidth(100)
+      editorElement.style.width = "100px"
+      editorElement.component.measureDimensions()
 
       initial = getLeftPosition(wrapGuide)
       expect(initial).toBeGreaterThan(0)
 
       editor.setScrollLeft(10)
-
       expect(getLeftPosition(wrapGuide)).toBe(initial - 10)
       expect(wrapGuide).toBeVisible()
 


### PR DESCRIPTION
This changes the specs so that they use the editor element to test visual changes, so that they still continue to pass as soon as we merge atom/atom#8905.

/cc: @nathansobo 