### PR TITLE
Always round wrap guide position

### DIFF
--- a/lib/wrap-guide-element.coffee
+++ b/lib/wrap-guide-element.coffee
@@ -89,7 +89,7 @@ class WrapGuideElement extends HTMLDivElement
         columnWidth -= @editorElement.getScrollLeft()
       else
         columnWidth -= @editor.getScrollLeft()
-      @style.left = "#{columnWidth}px"
+      @style.left = "#{Math.round(columnWidth)}px"
       @style.display = 'block'
     else
       @style.display = 'none'

--- a/spec/wrap-guide-spec.coffee
+++ b/spec/wrap-guide-spec.coffee
@@ -54,7 +54,7 @@ describe "WrapGuide", ->
     it "positions the guide at the configured column", ->
       width = editor.getDefaultCharWidth() * wrapGuide.getDefaultColumn()
       expect(width).toBeGreaterThan(0)
-      expect(getLeftPosition(wrapGuide)).toBe(width)
+      expect(getLeftPosition(wrapGuide)).toBeCloseTo width, 0
       expect(wrapGuide).toBeVisible()
 
   describe "when the font size changes", ->
@@ -133,14 +133,14 @@ describe "WrapGuide", ->
       wrapGuide.updateGuide()
       width = editor.getDefaultCharWidth() * 20
       expect(width).toBeGreaterThan(0)
-      expect(getLeftPosition(wrapGuide)).toBe(width)
+      expect(getLeftPosition(wrapGuide)).toBeCloseTo width, 0
 
     it "uses the default column when no custom column matches the path", ->
       atom.config.set('wrap-guide.columns', [{pattern: '\.jsp$', column: '100'}])
       wrapGuide.updateGuide()
       width = editor.getDefaultCharWidth() * wrapGuide.getDefaultColumn()
       expect(width).toBeGreaterThan(0)
-      expect(getLeftPosition(wrapGuide)).toBe(width)
+      expect(getLeftPosition(wrapGuide)).toBeCloseTo width, 0
 
     it "hides the guide when the config column is less than 1", ->
       atom.config.set('wrap-guide.columns', [{pattern: 'sample\.js$', column: -1}])
@@ -156,14 +156,14 @@ describe "WrapGuide", ->
       wrapGuide.updateGuide()
       width = editor.getDefaultCharWidth() * 20
       expect(width).toBeGreaterThan(0)
-      expect(getLeftPosition(wrapGuide)).toBe(width)
+      expect(getLeftPosition(wrapGuide)).toBeCloseTo width, 0
 
     it "uses the default column when no scope name matches", ->
       atom.config.set('wrap-guide.columns', [{scope: 'source.gfm', column: '100'}])
       wrapGuide.updateGuide()
       width = editor.getDefaultCharWidth() * wrapGuide.getDefaultColumn()
       expect(width).toBeGreaterThan(0)
-      expect(getLeftPosition(wrapGuide)).toBe(width)
+      expect(getLeftPosition(wrapGuide)).toBeCloseTo width, 0
 
     it "favors the first matching rule", ->
       atom.config.set('wrap-guide.columns', [{pattern: '\.js$', column: 20},
@@ -171,7 +171,7 @@ describe "WrapGuide", ->
       wrapGuide.updateGuide()
       width = editor.getDefaultCharWidth() * 20
       expect(width).toBeGreaterThan(0)
-      expect(getLeftPosition(wrapGuide)).toBe(width)
+      expect(getLeftPosition(wrapGuide)).toBeCloseTo width, 0
 
   describe 'scoped config', ->
     it '::getDefaultColumn returns the scope-specific column value', ->


### PR DESCRIPTION
Refs.: atom/atom#8811

We're enabling subpixel font scaling and, since this package uses `::getDefaultCharacterWidth`, it could now return a non-integer value.

This PR changes wrap-guide to always round the line position to the nearest integer.

/cc: @nathansobo