### PR TITLE
Adds support for multiple wrap guide lines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,12 @@ atom-text-editor .wrap-guide {
   background-color: red;
 }
 ```
+
+Multiple guide lines are also supported. For example, add the following to your `config.cson` to create four columns at the indicated positions:
+
+```coffeescript
+'wrap-guide':
+  'guides': [72, 80, 100, 120]
+```
+
+> Note: When using multiple guide lines, the right-most guide line functions as your `editor.preferredLineLength` setting.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Multiple guide lines are also supported. For example, add the following to your 
 
 ```coffeescript
 'wrap-guide':
-  'guides': [72, 80, 100, 120]
+  'columns': [72, 80, 100, 120]
 ```
 
 > Note: When using multiple guide lines, the right-most guide line functions as your `editor.preferredLineLength` setting.

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -21,3 +21,6 @@ module.exports =
     @subscriptions.dispose()
     @wrapGuides.forEach (wrapGuide, editor) -> wrapGuide.destroy()
     @wrapGuides.clear()
+
+  uniqueAscending: (list) ->
+    (list.filter((item, index) -> list.indexOf(item) is index)).sort((a, b) -> a - b)

--- a/lib/wrap-guide-element.coffee
+++ b/lib/wrap-guide-element.coffee
@@ -49,11 +49,11 @@ class WrapGuideElement
 
     updatePreferredLineLengthCallback = (args) =>
       # ensure that the right-most wrap guide is the preferredLineLength
-      multiGuides = atom.config.get('wrap-guide.guides', scope: @editor.getRootScopeDescriptor())
-      if multiGuides.length > 0
-        multiGuides[multiGuides.length - 1] = args.newValue
-        multiGuides = uniqueAscending(i for i in multiGuides when i <= args.newValue)
-        atom.config.set 'wrap-guide.guides', multiGuides,
+      columns = atom.config.get('wrap-guide.columns', scope: @editor.getRootScopeDescriptor())
+      if columns.length > 0
+        columns[columns.length - 1] = args.newValue
+        columns = uniqueAscending(i for i in columns when i <= args.newValue)
+        atom.config.set 'wrap-guide.columns', columns,
           scopeSelector: ".#{@editor.getGrammar().scopeName}"
       @updateGuide()
     @configSubscriptions.add atom.config.onDidChange(
@@ -71,14 +71,14 @@ class WrapGuideElement
 
     updateGuidesCallback = (args) =>
       # ensure that multiple guides stay sorted in ascending order
-      guides = uniqueAscending(args.newValue)
-      if guides?.length
-        atom.config.set('wrap-guide.guides', guides)
-        atom.config.set 'editor.preferredLineLength', guides[guides.length - 1],
+      columns = uniqueAscending(args.newValue)
+      if columns?.length
+        atom.config.set('wrap-guide.columns', columns)
+        atom.config.set 'editor.preferredLineLength', columns[columns.length - 1],
           scopeSelector: ".#{@editor.getGrammar().scopeName}"
         @updateGuide()
     @configSubscriptions.add atom.config.onDidChange(
-      'wrap-guide.guides',
+      'wrap-guide.columns',
       scope: @editor.getRootScopeDescriptor(),
       updateGuidesCallback
     )
@@ -87,8 +87,8 @@ class WrapGuideElement
     atom.config.get('editor.preferredLineLength', scope: @editor.getRootScopeDescriptor())
 
   getGuidesColumns: (path, scopeName) ->
-    multiGuides = atom.config.get('wrap-guide.guides', scope: @editor.getRootScopeDescriptor()) ? []
-    return multiGuides if multiGuides.length > 0
+    columns = atom.config.get('wrap-guide.columns', scope: @editor.getRootScopeDescriptor()) ? []
+    return columns if columns.length > 0
     return [@getDefaultColumn()]
 
   isEnabled: ->

--- a/lib/wrap-guide-element.coffee
+++ b/lib/wrap-guide-element.coffee
@@ -7,7 +7,7 @@ class WrapGuideElement
     @configSubscriptions = new CompositeDisposable()
     @element = document.createElement('div')
     @element.setAttribute('is', 'wrap-guide')
-    @element.classList.add('wrap-guide')
+    @element.classList.add('wrap-guide-container')
     @attachToLines()
     @handleEvents()
     @updateGuide()
@@ -45,35 +45,93 @@ class WrapGuideElement
       updateGuideCallback()
 
   handleConfigEvents: ->
-    updateGuideCallback = => @updateGuide()
+    {uniqueAscending} = require './main'
+
+    updatePreferredLineLengthCallback = (args) =>
+      # ensure that the right-most wrap guide is the preferredLineLength
+      multiGuides = atom.config.get('wrap-guide.guides', scope: @editor.getRootScopeDescriptor())
+      if multiGuides.length > 0
+        multiGuides[multiGuides.length - 1] = args.newValue
+        multiGuides = uniqueAscending(i for i in multiGuides when i <= args.newValue)
+        atom.config.set 'wrap-guide.guides', multiGuides,
+          scopeSelector: ".#{@editor.getGrammar().scopeName}"
+      @updateGuide()
     @configSubscriptions.add atom.config.onDidChange(
       'editor.preferredLineLength',
       scope: @editor.getRootScopeDescriptor(),
-      updateGuideCallback
+      updatePreferredLineLengthCallback
     )
+
+    updateGuideCallback = => @updateGuide()
     @configSubscriptions.add atom.config.onDidChange(
       'wrap-guide.enabled',
       scope: @editor.getRootScopeDescriptor(),
       updateGuideCallback
     )
 
+    updateGuidesCallback = (args) =>
+      # ensure that multiple guides stay sorted in ascending order
+      guides = uniqueAscending(args.newValue)
+      if guides?.length
+        atom.config.set('wrap-guide.guides', guides)
+        atom.config.set 'editor.preferredLineLength', guides[guides.length - 1],
+          scopeSelector: ".#{@editor.getGrammar().scopeName}"
+        @updateGuide()
+    @configSubscriptions.add atom.config.onDidChange(
+      'wrap-guide.guides',
+      scope: @editor.getRootScopeDescriptor(),
+      updateGuidesCallback
+    )
+
   getDefaultColumn: ->
     atom.config.get('editor.preferredLineLength', scope: @editor.getRootScopeDescriptor())
+
+  getGuidesColumns: (path, scopeName) ->
+    multiGuides = atom.config.get('wrap-guide.guides', scope: @editor.getRootScopeDescriptor()) ? []
+    return multiGuides if multiGuides.length > 0
+    return [@getDefaultColumn()]
 
   isEnabled: ->
     atom.config.get('wrap-guide.enabled', scope: @editor.getRootScopeDescriptor()) ? true
 
+  hide: ->
+    @element.style.display = 'none'
+
+  show: ->
+    @element.style.display = 'block'
+
   updateGuide: ->
-    column = @getDefaultColumn()
-    if column > 0 and @isEnabled()
-      columnWidth = @editorElement.getDefaultCharacterWidth() * column
-      columnWidth -= @editorElement.getScrollLeft()
-      @element.style.left = "#{Math.round(columnWidth)}px"
-      @element.style.display = 'block'
+    if @isEnabled()
+      @updateGuides()
     else
-      @element.style.display = 'none'
+      @hide()
+
+  updateGuides: ->
+    @removeGuides()
+    @appendGuides()
+    if @element.children.length
+      @show()
+    else
+      @hide()
 
   destroy: ->
     @element.remove()
     @subscriptions.dispose()
     @configSubscriptions.dispose()
+
+  removeGuides: ->
+    while @element.firstChild
+      @element.removeChild(@element.firstChild)
+
+  appendGuides: ->
+    columns = @getGuidesColumns(@editor.getPath(), @editor.getGrammar().scopeName)
+    for column in columns
+      @appendGuide(column) unless column < 0
+
+  appendGuide: (column) ->
+    columnWidth = @editorElement.getDefaultCharacterWidth() * column
+    columnWidth -= @editorElement.getScrollLeft()
+    guide = document.createElement('div')
+    guide.classList.add('wrap-guide')
+    guide.style.left = "#{Math.round(columnWidth)}px"
+    @element.appendChild(guide)

--- a/package.json
+++ b/package.json
@@ -8,6 +8,20 @@
   "engines": {
     "atom": "*"
   },
+  "configSchema": {
+    "guides": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Display guides at each of the listed character widths. Leave blank for one guide at your `editor.preferredLineLength`."
+    },
+    "enabled": {
+      "default": true,
+      "type": "boolean"
+    }
+  },
   "devDependencies": {
     "coffeelint": "^1.9.7"
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "atom": "*"
   },
   "configSchema": {
-    "guides": {
+    "columns": {
       "default": [],
       "type": "array",
       "items": {

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -1,4 +1,4 @@
-module.exports = {
+const helpers = {
   getWrapGuides () {
     wrapGuides = []
     for (const editor of atom.workspace.getTextEditors()) {
@@ -10,5 +10,11 @@ module.exports = {
 
   getLeftPosition (element) {
     return parseInt(element.style.left)
+  },
+
+  getLeftPositions (elements) {
+    return Array.prototype.map.call(elements, element => helpers.getLeftPosition(element))
   }
 }
+
+module.exports = helpers

--- a/spec/wrap-guide-element-spec.coffee
+++ b/spec/wrap-guide-element-spec.coffee
@@ -55,8 +55,8 @@ describe "WrapGuideElement", ->
       expect(wrapGuide).toBeVisible()
 
     it "appends multiple wrap guides to all existing and new editors", ->
-      guides = [10, 20, 30]
-      atom.config.set("wrap-guide.guides", guides)
+      columns = [10, 20, 30]
+      atom.config.set("wrap-guide.columns", columns)
 
       waitsForPromise ->
         editorElement.getComponent().getNextUpdatePromise()
@@ -65,7 +65,7 @@ describe "WrapGuideElement", ->
         expect(atom.workspace.getTextEditors().length).toBe 1
         expect(getWrapGuides().length).toBe 1
         positions = getLeftPositions(getWrapGuides()[0])
-        expect(positions.length).toBe(guides.length)
+        expect(positions.length).toBe(columns.length)
         expect(positions[0]).toBeGreaterThan(0)
         expect(positions[1]).toBeGreaterThan(positions[0])
         expect(positions[2]).toBeGreaterThan(positions[1])
@@ -74,7 +74,7 @@ describe "WrapGuideElement", ->
         expect(atom.workspace.getTextEditors().length).toBe 2
         expect(getWrapGuides().length).toBe 2
         pane1_positions = getLeftPositions(getWrapGuides()[0])
-        expect(pane1_positions.length).toBe(guides.length)
+        expect(pane1_positions.length).toBe(columns.length)
         expect(pane1_positions[0]).toBeGreaterThan(0)
         expect(pane1_positions[1]).toBeGreaterThan(pane1_positions[0])
         expect(pane1_positions[2]).toBeGreaterThan(pane1_positions[1])
@@ -86,8 +86,8 @@ describe "WrapGuideElement", ->
 
     it "positions multiple guides at the configured columns", ->
       columnCount = 5
-      guides = (c * 10 for c in [1..columnCount])
-      atom.config.set("wrap-guide.guides", guides)
+      columns = (c * 10 for c in [1..columnCount])
+      atom.config.set("wrap-guide.columns", columns)
       waitsForPromise ->
         editorElement.getComponent().getNextUpdatePromise()
 
@@ -97,7 +97,7 @@ describe "WrapGuideElement", ->
         expect(wrapGuide.children.length).toBe(columnCount)
 
         for i in columnCount - 1
-          width = editor.getDefaultCharWidth() * guides[i]
+          width = editor.getDefaultCharWidth() * columns[i]
           expect(width).toBeGreaterThan(0)
           expect(Math.abs(getLeftPosition(wrapGuide.children[i]) - width)).toBeLessThan 1
         expect(wrapGuide).toBeVisible()
@@ -147,7 +147,7 @@ describe "WrapGuideElement", ->
   describe "when the preferredLineLength changes", ->
     it "updates the wrap guide positions", ->
       initial = [10, 15, 20, 30]
-      atom.config.set 'wrap-guide.guides', initial,
+      atom.config.set 'wrap-guide.columns', initial,
         scopeSelector: ".#{editor.getGrammar().scopeName}"
       waitsForPromise ->
         editorElement.getComponent().getNextUpdatePromise()
@@ -159,25 +159,25 @@ describe "WrapGuideElement", ->
           editorElement.getComponent().getNextUpdatePromise()
 
         runs ->
-          guides = atom.config.get('wrap-guide.guides', scope: editor.getRootScopeDescriptor())
-          expect(guides.length).toBe(2)
-          expect(guides[0]).toBe(10)
-          expect(guides[1]).toBe(15)
+          columns = atom.config.get('wrap-guide.columns', scope: editor.getRootScopeDescriptor())
+          expect(columns.length).toBe(2)
+          expect(columns[0]).toBe(10)
+          expect(columns[1]).toBe(15)
 
-  describe "when the guides config changes", ->
+  describe "when the columns config changes", ->
     it "updates the wrap guide positions", ->
       initial = getLeftPositions(wrapGuide.children)
       expect(initial.length).toBe(1)
       expect(initial[0]).toBeGreaterThan(0)
 
-      guides = [10, 20, 30]
-      atom.config.set("wrap-guide.guides", guides)
+      columns = [10, 20, 30]
+      atom.config.set("wrap-guide.columns", columns)
       waitsForPromise ->
         editorElement.getComponent().getNextUpdatePromise()
 
       runs ->
         positions = getLeftPositions(wrapGuide.children)
-        expect(positions.length).toBe(guides.length)
+        expect(positions.length).toBe(columns.length)
         expect(positions[0]).toBeGreaterThan(0)
         expect(positions[1]).toBeGreaterThan(positions[0])
         expect(positions[2]).toBeGreaterThan(positions[1])
@@ -185,7 +185,7 @@ describe "WrapGuideElement", ->
 
     it "updates the preferredLineLength", ->
       initial = atom.config.get('editor.preferredLineLength', scope: editor.getRootScopeDescriptor())
-      atom.config.set("wrap-guide.guides", [initial, initial + 10])
+      atom.config.set("wrap-guide.columns", [initial, initial + 10])
       waitsForPromise ->
         editorElement.getComponent().getNextUpdatePromise()
 
@@ -198,21 +198,21 @@ describe "WrapGuideElement", ->
       expect(initial.length).toBe(1)
       expect(initial[0]).toBeGreaterThan(0)
 
-      reverseGuides = [30, 20, 10]
-      guides = [reverseGuides[reverseGuides.length - 1], reverseGuides..., reverseGuides[0]]
-      uniqueGuides = uniqueAscending(guides)
-      expect(uniqueGuides.length).toBe(3)
-      expect(uniqueGuides[0]).toBeGreaterThan(0)
-      expect(uniqueGuides[1]).toBeGreaterThan(uniqueGuides[0])
-      expect(uniqueGuides[2]).toBeGreaterThan(uniqueGuides[1])
+      reverseColumns = [30, 20, 10]
+      columns = [reverseColumns[reverseColumns.length - 1], reverseColumns..., reverseColumns[0]]
+      uniqueColumns = uniqueAscending(columns)
+      expect(uniqueColumns.length).toBe(3)
+      expect(uniqueColumns[0]).toBeGreaterThan(0)
+      expect(uniqueColumns[1]).toBeGreaterThan(uniqueColumns[0])
+      expect(uniqueColumns[2]).toBeGreaterThan(uniqueColumns[1])
 
-      atom.config.set("wrap-guide.guides", guides)
+      atom.config.set("wrap-guide.columns", columns)
       waitsForPromise ->
         editorElement.getComponent().getNextUpdatePromise()
 
       runs ->
         positions = getLeftPositions(wrapGuide.children)
-        expect(positions.length).toBe(uniqueGuides.length)
+        expect(positions.length).toBe(uniqueColumns.length)
         expect(positions[0]).toBeGreaterThan(0)
         expect(positions[1]).toBeGreaterThan(positions[0])
         expect(positions[2]).toBeGreaterThan(positions[1])

--- a/spec/wrap-guide-element-spec.coffee
+++ b/spec/wrap-guide-element-spec.coffee
@@ -1,4 +1,5 @@
-{getLeftPosition} = require './helpers'
+{getLeftPosition, getLeftPositions} = require './helpers'
+{uniqueAscending} = require '../lib/main'
 
 describe "WrapGuideElement", ->
   [editor, editorElement, wrapGuide, workspaceElement] = []
@@ -25,11 +26,85 @@ describe "WrapGuideElement", ->
     runs ->
       editor = atom.workspace.getActiveTextEditor()
       editorElement = editor.getElement()
-      wrapGuide = editorElement.querySelector(".wrap-guide")
+      wrapGuide = editorElement.querySelector(".wrap-guide-container")
+
+  describe ".activate", ->
+    getWrapGuides = ->
+      wrapGuides = []
+      atom.workspace.getTextEditors().forEach (editor) ->
+        guides = editor.getElement().querySelectorAll(".wrap-guide")
+        wrapGuides.push(guides) if guides
+      wrapGuides
+
+    it "appends a wrap guide to all existing and new editors", ->
+      expect(atom.workspace.getTextEditors().length).toBe 1
+
+      expect(getWrapGuides().length).toBe 1
+      expect(getLeftPosition(getWrapGuides()[0][0])).toBeGreaterThan(0)
+
+      atom.workspace.getActivePane().splitRight(copyActiveItem: true)
+      expect(atom.workspace.getTextEditors().length).toBe 2
+      expect(getWrapGuides().length).toBe 2
+      expect(getLeftPosition(getWrapGuides()[0][0])).toBeGreaterThan(0)
+      expect(getLeftPosition(getWrapGuides()[1][0])).toBeGreaterThan(0)
+
+    it "positions the guide at the configured column", ->
+      width = editor.getDefaultCharWidth() * wrapGuide.getDefaultColumn()
+      expect(width).toBeGreaterThan(0)
+      expect(Math.abs(getLeftPosition(wrapGuide.firstChild) - width)).toBeLessThan 1
+      expect(wrapGuide).toBeVisible()
+
+    it "appends multiple wrap guides to all existing and new editors", ->
+      guides = [10, 20, 30]
+      atom.config.set("wrap-guide.guides", guides)
+
+      waitsForPromise ->
+        editorElement.getComponent().getNextUpdatePromise()
+
+      runs ->
+        expect(atom.workspace.getTextEditors().length).toBe 1
+        expect(getWrapGuides().length).toBe 1
+        positions = getLeftPositions(getWrapGuides()[0])
+        expect(positions.length).toBe(guides.length)
+        expect(positions[0]).toBeGreaterThan(0)
+        expect(positions[1]).toBeGreaterThan(positions[0])
+        expect(positions[2]).toBeGreaterThan(positions[1])
+
+        atom.workspace.getActivePane().splitRight(copyActiveItem: true)
+        expect(atom.workspace.getTextEditors().length).toBe 2
+        expect(getWrapGuides().length).toBe 2
+        pane1_positions = getLeftPositions(getWrapGuides()[0])
+        expect(pane1_positions.length).toBe(guides.length)
+        expect(pane1_positions[0]).toBeGreaterThan(0)
+        expect(pane1_positions[1]).toBeGreaterThan(pane1_positions[0])
+        expect(pane1_positions[2]).toBeGreaterThan(pane1_positions[1])
+        pane2_positions = getLeftPositions(getWrapGuides()[1])
+        expect(pane2_positions.length).toBe(pane1_positions.length)
+        expect(pane2_positions[0]).toBe(pane1_positions[0])
+        expect(pane2_positions[1]).toBe(pane1_positions[1])
+        expect(pane2_positions[2]).toBe(pane1_positions[2])
+
+    it "positions multiple guides at the configured columns", ->
+      columnCount = 5
+      guides = (c * 10 for c in [1..columnCount])
+      atom.config.set("wrap-guide.guides", guides)
+      waitsForPromise ->
+        editorElement.getComponent().getNextUpdatePromise()
+
+      runs ->
+        positions = getLeftPositions(getWrapGuides()[0])
+        expect(positions.length).toBe(columnCount)
+        expect(wrapGuide.children.length).toBe(columnCount)
+
+        for i in columnCount - 1
+          width = editor.getDefaultCharWidth() * guides[i]
+          expect(width).toBeGreaterThan(0)
+          expect(Math.abs(getLeftPosition(wrapGuide.children[i]) - width)).toBeLessThan 1
+        expect(wrapGuide).toBeVisible()
 
   describe "when the font size changes", ->
     it "updates the wrap guide position", ->
-      initial = getLeftPosition(wrapGuide)
+      initial = getLeftPosition(wrapGuide.firstChild)
       expect(initial).toBeGreaterThan(0)
       fontSize = atom.config.get("editor.fontSize")
       atom.config.set("editor.fontSize", fontSize + 10)
@@ -38,11 +113,11 @@ describe "WrapGuideElement", ->
         editorElement.getComponent().getNextUpdatePromise()
 
       runs ->
-        expect(getLeftPosition(wrapGuide)).toBeGreaterThan(initial)
-        expect(wrapGuide).toBeVisible()
+        expect(getLeftPosition(wrapGuide.firstChild)).toBeGreaterThan(initial)
+        expect(wrapGuide.firstChild).toBeVisible()
 
     it "updates the wrap guide position for hidden editors when they become visible", ->
-      initial = getLeftPosition(wrapGuide)
+      initial = getLeftPosition(wrapGuide.firstChild)
       expect(initial).toBeGreaterThan(0)
 
       waitsForPromise ->
@@ -57,17 +132,91 @@ describe "WrapGuideElement", ->
           editorElement.getComponent().getNextUpdatePromise()
 
         runs ->
-          expect(getLeftPosition(wrapGuide)).toBeGreaterThan(initial)
-          expect(wrapGuide).toBeVisible()
+          expect(getLeftPosition(wrapGuide.firstChild)).toBeGreaterThan(initial)
+          expect(wrapGuide.firstChild).toBeVisible()
 
   describe "when the column config changes", ->
     it "updates the wrap guide position", ->
-      initial = getLeftPosition(wrapGuide)
+      initial = getLeftPosition(wrapGuide.firstChild)
       expect(initial).toBeGreaterThan(0)
       column = atom.config.get("editor.preferredLineLength")
       atom.config.set("editor.preferredLineLength", column + 10)
-      expect(getLeftPosition(wrapGuide)).toBeGreaterThan(initial)
+      expect(getLeftPosition(wrapGuide.firstChild)).toBeGreaterThan(initial)
       expect(wrapGuide).toBeVisible()
+
+  describe "when the preferredLineLength changes", ->
+    it "updates the wrap guide positions", ->
+      initial = [10, 15, 20, 30]
+      atom.config.set 'wrap-guide.guides', initial,
+        scopeSelector: ".#{editor.getGrammar().scopeName}"
+      waitsForPromise ->
+        editorElement.getComponent().getNextUpdatePromise()
+
+      runs ->
+        atom.config.set 'editor.preferredLineLength', 15,
+          scopeSelector: ".#{editor.getGrammar().scopeName}"
+        waitsForPromise ->
+          editorElement.getComponent().getNextUpdatePromise()
+
+        runs ->
+          guides = atom.config.get('wrap-guide.guides', scope: editor.getRootScopeDescriptor())
+          expect(guides.length).toBe(2)
+          expect(guides[0]).toBe(10)
+          expect(guides[1]).toBe(15)
+
+  describe "when the guides config changes", ->
+    it "updates the wrap guide positions", ->
+      initial = getLeftPositions(wrapGuide.children)
+      expect(initial.length).toBe(1)
+      expect(initial[0]).toBeGreaterThan(0)
+
+      guides = [10, 20, 30]
+      atom.config.set("wrap-guide.guides", guides)
+      waitsForPromise ->
+        editorElement.getComponent().getNextUpdatePromise()
+
+      runs ->
+        positions = getLeftPositions(wrapGuide.children)
+        expect(positions.length).toBe(guides.length)
+        expect(positions[0]).toBeGreaterThan(0)
+        expect(positions[1]).toBeGreaterThan(positions[0])
+        expect(positions[2]).toBeGreaterThan(positions[1])
+        expect(wrapGuide).toBeVisible()
+
+    it "updates the preferredLineLength", ->
+      initial = atom.config.get('editor.preferredLineLength', scope: editor.getRootScopeDescriptor())
+      atom.config.set("wrap-guide.guides", [initial, initial + 10])
+      waitsForPromise ->
+        editorElement.getComponent().getNextUpdatePromise()
+
+      runs ->
+        length = atom.config.get('editor.preferredLineLength', scope: editor.getRootScopeDescriptor())
+        expect(length).toBe(initial + 10)
+
+    it "keeps guide positions unique and in ascending order", ->
+      initial = getLeftPositions(wrapGuide.children)
+      expect(initial.length).toBe(1)
+      expect(initial[0]).toBeGreaterThan(0)
+
+      reverseGuides = [30, 20, 10]
+      guides = [reverseGuides[reverseGuides.length - 1], reverseGuides..., reverseGuides[0]]
+      uniqueGuides = uniqueAscending(guides)
+      expect(uniqueGuides.length).toBe(3)
+      expect(uniqueGuides[0]).toBeGreaterThan(0)
+      expect(uniqueGuides[1]).toBeGreaterThan(uniqueGuides[0])
+      expect(uniqueGuides[2]).toBeGreaterThan(uniqueGuides[1])
+
+      atom.config.set("wrap-guide.guides", guides)
+      waitsForPromise ->
+        editorElement.getComponent().getNextUpdatePromise()
+
+      runs ->
+        positions = getLeftPositions(wrapGuide.children)
+        expect(positions.length).toBe(uniqueGuides.length)
+        expect(positions[0]).toBeGreaterThan(0)
+        expect(positions[1]).toBeGreaterThan(positions[0])
+        expect(positions[2]).toBeGreaterThan(positions[1])
+        expect(wrapGuide).toBeVisible()
 
   describe "when the editor's scroll left changes", ->
     it "updates the wrap guide position to a relative position on screen", ->
@@ -77,28 +226,28 @@ describe "WrapGuideElement", ->
       waitsFor -> editorElement.component.getMaxScrollLeft() > 10
 
       runs ->
-        initial = getLeftPosition(wrapGuide)
+        initial = getLeftPosition(wrapGuide.firstChild)
         expect(initial).toBeGreaterThan(0)
         editorElement.setScrollLeft(10)
-        expect(getLeftPosition(wrapGuide)).toBe(initial - 10)
-        expect(wrapGuide).toBeVisible()
+        expect(getLeftPosition(wrapGuide.firstChild)).toBe(initial - 10)
+        expect(wrapGuide.firstChild).toBeVisible()
 
   describe "when the editor's grammar changes", ->
     it "updates the wrap guide position", ->
       atom.config.set('editor.preferredLineLength', 20, scopeSelector: '.source.js')
-      initial = getLeftPosition(wrapGuide)
+      initial = getLeftPosition(wrapGuide.firstChild)
       expect(initial).toBeGreaterThan(0)
       expect(wrapGuide).toBeVisible()
 
       editor.setGrammar(atom.grammars.grammarForScopeName('text.plain.null-grammar'))
-      expect(getLeftPosition(wrapGuide)).toBeGreaterThan(initial)
+      expect(getLeftPosition(wrapGuide.firstChild)).toBeGreaterThan(initial)
       expect(wrapGuide).toBeVisible()
 
     it 'listens for preferredLineLength updates for the new grammar', ->
       editor.setGrammar(atom.grammars.grammarForScopeName('source.coffee'))
-      initial = getLeftPosition(wrapGuide)
+      initial = getLeftPosition(wrapGuide.firstChild)
       atom.config.set('editor.preferredLineLength', 20, scopeSelector: '.source.coffee')
-      expect(getLeftPosition(wrapGuide)).toBeLessThan(initial)
+      expect(getLeftPosition(wrapGuide.firstChild)).toBeLessThan(initial)
 
     it 'listens for wrap-guide.enabled updates for the new grammar', ->
       editor.setGrammar(atom.grammars.grammarForScopeName('source.coffee'))
@@ -113,10 +262,10 @@ describe "WrapGuideElement", ->
       expect(wrapGuide.getDefaultColumn()).toBe 132
 
     it 'updates the guide when the scope-specific column changes', ->
-      initial = getLeftPosition(wrapGuide)
+      initial = getLeftPosition(wrapGuide.firstChild)
       column = atom.config.get('editor.preferredLineLength', scope: editor.getRootScopeDescriptor())
       atom.config.set('editor.preferredLineLength', column + 10, scope: '.source.js')
-      expect(getLeftPosition(wrapGuide)).toBeGreaterThan(initial)
+      expect(getLeftPosition(wrapGuide.firstChild)).toBeGreaterThan(initial)
 
     it 'updates the guide when wrap-guide.enabled is set to false', ->
       expect(wrapGuide).toBeVisible()

--- a/spec/wrap-guide-spec.js
+++ b/spec/wrap-guide-spec.js
@@ -10,7 +10,7 @@ describe('Wrap Guide', () => {
 
     editor = await atom.workspace.open('sample.js')
     editorElement = editor.getElement()
-    wrapGuide = editorElement.querySelector('.wrap-guide')
+    wrapGuide = editorElement.querySelector('.wrap-guide-container')
 
     jasmine.attachToDOM(atom.views.getView(atom.workspace))
   })
@@ -31,8 +31,8 @@ describe('Wrap Guide', () => {
     it('positions the guide at the configured column', () => {
       width = editor.getDefaultCharWidth() * wrapGuide.getDefaultColumn()
       expect(width).toBeGreaterThan(0)
-      expect(Math.abs(getLeftPosition(wrapGuide) - width)).toBeLessThan(1)
-      expect(wrapGuide).toBeVisible()
+      expect(Math.abs(getLeftPosition(wrapGuide.firstChild) - width)).toBeLessThan(1)
+      expect(wrapGuide.firstChild).toBeVisible()
     })
   })
 


### PR DESCRIPTION
This patch creates guides at the columns listed in `wrap-guide.guides`.
Unfortunately `wrap-guide.columns` is a deprecated setting and I want to
avoid any potential conflicts.

It also creates a distinction between element `.wrap-guide` and a new
element, `.wrap-guide-container`. The container class now contains
multiple child nodes of class `.wrap-guide`. Tests updated accordingly.

Configuring guide styles will still work as indicated in `README.md`.

Potential weirdnesses:
- The `wrap-guide.guides` setting is not language-specific.
- Soft wrap is still governed by `editor.preferredLineLength`, which is
  language-specific. This can differ with the setting for the right
  most guide, causing dissonance.

Closes #14.
