### PR TITLE
Stop using shadow DOM selectors

### DIFF
--- a/styles/wrap-guide.less
+++ b/styles/wrap-guide.less
@@ -1,6 +1,6 @@
 @import "syntax-variables";
 
-atom-text-editor::shadow {
+atom-text-editor {
   .wrap-guide {
     height: 100%;
     width: 1px;


### PR DESCRIPTION
We are in the process of removing the shadow DOM boundary from `atom-text-editor` elements. This pull request upgrades existing selectors so that they:

* Stop using `:host`.
* Stop using `atom-text-editor::shadow`.
* Prepend syntax class names with `syntax--`.

/cc: @simurai