### PR TITLE
Count the number of editors (not panes) when testing wrap guide count

### DIFF
--- a/spec/wrap-guide-spec.coffee
+++ b/spec/wrap-guide-spec.coffee
@@ -41,12 +41,12 @@ describe "WrapGuide", ->
       wrapGuides
 
     it "appends a wrap guide to all existing and new editors", ->
-      expect(atom.workspace.getPanes().length).toBe 1
+      expect(atom.workspace.getTextEditors().length).toBe 1
       expect(getWrapGuides().length).toBe 1
       expect(getLeftPosition(getWrapGuides()[0])).toBeGreaterThan(0)
 
       atom.workspace.getActivePane().splitRight(copyActiveItem: true)
-      expect(atom.workspace.getPanes().length).toBe 2
+      expect(atom.workspace.getTextEditors().length).toBe 2
       expect(getWrapGuides().length).toBe 2
       expect(getLeftPosition(getWrapGuides()[0])).toBeGreaterThan(0)
       expect(getLeftPosition(getWrapGuides()[1])).toBeGreaterThan(0)


### PR DESCRIPTION
atom/atom#13977 adds multiple pane locations and updates the
atom.workspace.getPanes() API to return the panes from all of them.
This fixes the resultant test failures by making assertions about the
number of text editors instead of the number of panes (which I think is
more true to the intent of the test).