### PR TITLE
Tweak package to accommodate the new editor rendering layer

### DIFF
--- a/lib/wrap-guide-element.coffee
+++ b/lib/wrap-guide-element.coffee
@@ -14,8 +14,8 @@ class WrapGuideElement
     @element.getDefaultColumn = @getDefaultColumn.bind(this)
 
   attachToLines: ->
-    lines = @editorElement.rootElement?.querySelector?('.lines')
-    lines?.appendChild(@element)
+    scrollView = @editorElement.querySelector('.scroll-view')
+    scrollView?.appendChild(@element)
 
   handleEvents: ->
     updateGuideCallback = => @updateGuide()

--- a/spec/wrap-guide-spec.coffee
+++ b/spec/wrap-guide-spec.coffee
@@ -30,13 +30,13 @@ describe "WrapGuide", ->
     runs ->
       editor = atom.workspace.getActiveTextEditor()
       editorElement = editor.getElement()
-      wrapGuide = editorElement.rootElement.querySelector(".wrap-guide")
+      wrapGuide = editorElement.querySelector(".wrap-guide")
 
   describe ".activate", ->
     getWrapGuides  = ->
       wrapGuides = []
       atom.workspace.getTextEditors().forEach (editor) ->
-        guide = editor.getElement().rootElement.querySelector(".wrap-guide")
+        guide = editor.getElement().querySelector(".wrap-guide")
         wrapGuides.push(guide) if guide
       wrapGuides
 
@@ -83,14 +83,16 @@ describe "WrapGuide", ->
 
   describe "when the editor's scroll left changes", ->
     it "updates the wrap guide position to a relative position on screen", ->
-      spyOn(editorElement.component, 'measureDimensions').andCallThrough()
       editor.setText("a long line which causes the editor to scroll")
       editorElement.style.width = "100px"
 
       if atom.views.performDocumentPoll # TODO: Remove this branch once atom.views.performDocumentPoll is gone
         atom.views.performDocumentPoll()
+      else if editorElement.component.presenter?
+        presenter = editorElement.component.presenter
+        waitsFor -> (presenter.scrollWidth - presenter.clientWidth) > 10
       else
-        waitsFor -> editorElement.component.measureDimensions.callCount > 0
+        waitsFor -> editorElement.component.getMaxScrollLeft() > 10
 
       runs ->
         initial = getLeftPosition(wrapGuide)


### PR DESCRIPTION
Refs: atom/atom#13880

This pull requests changes the position of the wrap-guide and inserts it inside the `.scroll-view` element, so that the wrap-guide is always as tall as the editor container.

/cc: @nathansobo 