### PR TITLE
Don't watch editors more than once if they're re-added to the workspace

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -5,10 +5,16 @@ WrapGuideElement = require './wrap-guide-element'
 module.exports =
   activate: ->
     @updateConfiguration()
+    watchedEditors = new WeakSet()
 
     atom.workspace.observeTextEditors (editor) ->
+      return if watchedEditors.has(editor)
+
       editorElement = atom.views.getView(editor)
       wrapGuideElement = new WrapGuideElement(editor, editorElement)
+
+      watchedEditors.add(editor)
+      editor.onDidDestroy -> watchedEditors.delete(editor)
 
   updateConfiguration: ->
     customColumns = atom.config.get('wrap-guide.columns')


### PR DESCRIPTION
This will prevent this package from providing its functionality to editors more than once in case they get added to the workspace, then removed from it and finally added back.

/cc: @nathansobo @jasonrudolph