### PR TITLE
:bug: Disable pointer events on .wrap-guide

### DIFF
--- a/styles/wrap-guide.less
+++ b/styles/wrap-guide.less
@@ -9,5 +9,6 @@ atom-text-editor {
     top: 0;
     background-color: @syntax-wrap-guide-color;
     -webkit-transform: translateZ(0);
+    pointer-events: none;
   }
 }


### PR DESCRIPTION
### Description of the Change

Disable pointer events on the wrap guide in order to fix the bug where clicking precisely on the wrap guide (even though it is only a single pixel wide) would capture clicks, preventing you from switching lines in the TextEditor.

### Alternate Designs

I'm not aware of any alternative solutions for this problem.

### Benefits

Although it is a rare occurrence that one clicks precisely on that one pixel wide wrap-guide, it can happen and it is annoying if it doesn't do what you expect it to do.

### Possible Drawbacks

None, as far as I know

### Applicable Issues

None
