### PR TITLE
Remove deprecated `wrap-guide.columns` config option

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,34 +1,7 @@
-Grim = require 'grim'
-
 WrapGuideElement = require './wrap-guide-element'
 
 module.exports =
   activate: ->
-    @updateConfiguration()
-
     atom.workspace.observeTextEditors (editor) ->
       editorElement = atom.views.getView(editor)
       wrapGuideElement = new WrapGuideElement(editor, editorElement)
-
-  updateConfiguration: ->
-    customColumns = atom.config.get('wrap-guide.columns')
-    return unless customColumns
-
-    newColumns = []
-    for customColumn in customColumns when typeof customColumn is 'object'
-      {pattern, scope, column} = customColumn
-      if Grim.includeDeprecatedAPIs and pattern
-        Grim.deprecate """
-          The Wrap Guide package uses Atom's new language-specific configuration.
-          Use of file name matching patterns for Wrap Guide configuration is deprecated.
-          See the README for details: https://github.com/atom/wrap-guide.
-        """
-        newColumns.push(customColumn)
-      else if scope
-        if column is -1
-          atom.config.set('wrap-guide.enabled', false, scopeSelector: ".#{scope}")
-        else
-          atom.config.set('editor.preferredLineLength', column, scopeSelector: ".#{scope}")
-
-    newColumns = undefined if newColumns.length is 0
-    atom.config.set('wrap-guide.columns', newColumns)

--- a/lib/wrap-guide-element.coffee
+++ b/lib/wrap-guide-element.coffee
@@ -22,7 +22,6 @@ class WrapGuideElement
 
     subscriptions = new CompositeDisposable
     configSubscriptions = @handleConfigEvents()
-    subscriptions.add atom.config.onDidChange('wrap-guide.columns', updateGuideCallback)
     subscriptions.add atom.config.onDidChange 'editor.fontSize', ->
       # setTimeout because we need to wait for the editor measurement to happen
       setTimeout(updateGuideCallback, 0)
@@ -60,27 +59,11 @@ class WrapGuideElement
   getDefaultColumn: ->
     atom.config.get('editor.preferredLineLength', scope: @editor.getRootScopeDescriptor())
 
-  getGuideColumn: (path, scopeName) ->
-    customColumns = atom.config.get('wrap-guide.columns')
-    return @getDefaultColumn() unless Array.isArray(customColumns)
-
-    for customColumn in customColumns when typeof customColumn is 'object'
-      {pattern, scope, column} = customColumn
-      if pattern
-        try
-          regex = new RegExp(pattern)
-        catch
-          continue
-        return parseInt(column) if regex.test(path)
-      else if scope
-        return parseInt(column) if scope is scopeName
-    @getDefaultColumn()
-
   isEnabled: ->
     atom.config.get('wrap-guide.enabled', scope: @editor.getRootScopeDescriptor()) ? true
 
   updateGuide: ->
-    column = @getGuideColumn(@editor.getPath(), @editor.getGrammar().scopeName)
+    column = @getDefaultColumn()
     if column > 0 and @isEnabled()
       columnWidth = @editorElement.getDefaultCharacterWidth() * column
       columnWidth -= @editorElement.getScrollLeft()

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
   "engines": {
     "atom": "*"
   },
-  "dependencies": {
-    "grim": "^2.0.1"
-  },
   "devDependencies": {
     "coffeelint": "^1.9.7"
   }

--- a/spec/wrap-guide-spec.coffee
+++ b/spec/wrap-guide-spec.coffee
@@ -1,5 +1,3 @@
-Grim = require 'grim'
-
 # TODO: remove references to logical display buffer when it is released.
 
 describe "WrapGuide", ->
@@ -77,10 +75,6 @@ describe "WrapGuide", ->
       expect(getLeftPosition(wrapGuide)).toBeGreaterThan(initial)
       expect(wrapGuide).toBeVisible()
 
-      atom.config.set("wrap-guide.columns", [{pattern: ".*", column: column - 10}])
-      expect(getLeftPosition(wrapGuide)).toBeLessThan(initial)
-      expect(wrapGuide).toBeVisible()
-
   describe "when the editor's scroll left changes", ->
     it "updates the wrap guide position to a relative position on screen", ->
       editor.setText("a long line which causes the editor to scroll")
@@ -123,52 +117,6 @@ describe "WrapGuide", ->
       expect(wrapGuide).toBeVisible()
       atom.config.set('wrap-guide.enabled', false, scopeSelector: '.source.coffee')
       expect(wrapGuide).not.toBeVisible()
-
-  describe "using a custom config column", ->
-    it "places the wrap guide at the custom column", ->
-      atom.config.set('wrap-guide.columns', [{pattern: '\.js$', column: 20}])
-      wrapGuide.updateGuide()
-      width = editor.getDefaultCharWidth() * 20
-      expect(width).toBeGreaterThan(0)
-      expect(Math.abs(getLeftPosition(wrapGuide) - width)).toBeLessThan 1
-
-    it "uses the default column when no custom column matches the path", ->
-      atom.config.set('wrap-guide.columns', [{pattern: '\.jsp$', column: '100'}])
-      wrapGuide.updateGuide()
-      width = editor.getDefaultCharWidth() * wrapGuide.getDefaultColumn()
-      expect(width).toBeGreaterThan(0)
-      expect(Math.abs(getLeftPosition(wrapGuide) - width)).toBeLessThan 1
-
-    it "hides the guide when the config column is less than 1", ->
-      atom.config.set('wrap-guide.columns', [{pattern: 'sample\.js$', column: -1}])
-      wrapGuide.updateGuide()
-      expect(wrapGuide).toBeHidden()
-
-    it "ignores invalid regexes", ->
-      atom.config.set('wrap-guide.columns', [{pattern: '(', column: -1}])
-      expect(-> wrapGuide.updateGuide()).not.toThrow()
-
-    it "places the wrap guide at the custom column using scope name", ->
-      atom.config.set('wrap-guide.columns', [{scope: 'source.js', column: 20}])
-      wrapGuide.updateGuide()
-      width = editor.getDefaultCharWidth() * 20
-      expect(width).toBeGreaterThan(0)
-      expect(Math.abs(getLeftPosition(wrapGuide) - width)).toBeLessThan 1
-
-    it "uses the default column when no scope name matches", ->
-      atom.config.set('wrap-guide.columns', [{scope: 'source.gfm', column: '100'}])
-      wrapGuide.updateGuide()
-      width = editor.getDefaultCharWidth() * wrapGuide.getDefaultColumn()
-      expect(width).toBeGreaterThan(0)
-      expect(Math.abs(getLeftPosition(wrapGuide) - width)).toBeLessThan 1
-
-    it "favors the first matching rule", ->
-      atom.config.set('wrap-guide.columns', [{pattern: '\.js$', column: 20},
-                                             {pattern: 'sample\.js$', column: 30}])
-      wrapGuide.updateGuide()
-      width = editor.getDefaultCharWidth() * 20
-      expect(width).toBeGreaterThan(0)
-      expect(Math.abs(getLeftPosition(wrapGuide) - width)).toBeLessThan 1
 
   describe 'scoped config', ->
     it '::getDefaultColumn returns the scope-specific column value', ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

`wrap-guide.columns` has been deprecated for almost three years now, so I think it's safe to finally remove it.

### Alternate Designs

None.

### Benefits

Removes a lot of legacy conversion code due to the continued existence of `wrap-guide.columns`.

### Possible Drawbacks

Anyone still using the `pattern` property of `wrap-guide.columns` will have to manually update their config.

### Applicable Issues

None.