### PR TITLE
Deactivate properly

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,14 +1,19 @@
+{CompositeDisposable} = require 'atom'
 WrapGuideElement = require './wrap-guide-element'
 
 module.exports =
   activate: ->
     watchedEditors = new WeakSet()
+    @subscriptions = new CompositeDisposable()
 
-    atom.workspace.observeTextEditors (editor) ->
+    @subscriptions.add atom.workspace.observeTextEditors (editor) ->
       return if watchedEditors.has(editor)
 
       editorElement = atom.views.getView(editor)
       wrapGuideElement = new WrapGuideElement(editor, editorElement)
 
       watchedEditors.add(editor)
-      editor.onDidDestroy -> watchedEditors.delete(editor)
+      @subscriptions.add editor.onDidDestroy -> watchedEditors.delete(editor)
+
+  deactivate: ->
+    @subscriptions.dispose()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -3,17 +3,21 @@ WrapGuideElement = require './wrap-guide-element'
 
 module.exports =
   activate: ->
-    watchedEditors = new WeakSet()
     @subscriptions = new CompositeDisposable()
+    @wrapGuides = new Map()
 
-    @subscriptions.add atom.workspace.observeTextEditors (editor) ->
-      return if watchedEditors.has(editor)
+    @subscriptions.add atom.workspace.observeTextEditors (editor) =>
+      return if @wrapGuides.has(editor)
 
       editorElement = atom.views.getView(editor)
       wrapGuideElement = new WrapGuideElement(editor, editorElement)
 
-      watchedEditors.add(editor)
-      @subscriptions.add editor.onDidDestroy -> watchedEditors.delete(editor)
+      @wrapGuides.set(editor, wrapGuideElement)
+      @subscriptions.add editor.onDidDestroy =>
+        @wrapGuides.get(editor).destroy()
+        @wrapGuides.delete(editor)
 
   deactivate: ->
     @subscriptions.dispose()
+    @wrapGuides.forEach (wrapGuide, editor) -> wrapGuide.destroy()
+    @wrapGuides.clear()

--- a/spec/async-spec-helpers.js
+++ b/spec/async-spec-helpers.js
@@ -1,0 +1,103 @@
+/** @babel */
+
+export function beforeEach (fn) {
+  global.beforeEach(function () {
+    const result = fn()
+    if (result instanceof Promise) {
+      waitsForPromise(() => result)
+    }
+  })
+}
+
+export function afterEach (fn) {
+  global.afterEach(function () {
+    const result = fn()
+    if (result instanceof Promise) {
+      waitsForPromise(() => result)
+    }
+  })
+}
+
+['it', 'fit', 'ffit', 'fffit'].forEach(function (name) {
+  module.exports[name] = function (description, fn) {
+    if (fn === undefined) {
+      global[name](description)
+      return
+    }
+
+    global[name](description, function () {
+      const result = fn()
+      if (result instanceof Promise) {
+        waitsForPromise(() => result)
+      }
+    })
+  }
+})
+
+export async function conditionPromise (condition, description = 'anonymous condition') {
+  const startTime = Date.now()
+
+  while (true) {
+    await timeoutPromise(100)
+
+    if (await condition()) {
+      return
+    }
+
+    if (Date.now() - startTime > 5000) {
+      throw new Error('Timed out waiting on ' + description)
+    }
+  }
+}
+
+export function timeoutPromise (timeout) {
+  return new Promise(function (resolve) {
+    global.setTimeout(resolve, timeout)
+  })
+}
+
+function waitsForPromise (fn) {
+  const promise = fn()
+  global.waitsFor('spec promise to resolve', function (done) {
+    promise.then(done, function (error) {
+      jasmine.getEnv().currentSpec.fail(error)
+      done()
+    })
+  })
+}
+
+export function emitterEventPromise (emitter, event, timeout = 15000) {
+  return new Promise((resolve, reject) => {
+    const timeoutHandle = setTimeout(() => {
+      reject(new Error(`Timed out waiting for '${event}' event`))
+    }, timeout)
+    emitter.once(event, () => {
+      clearTimeout(timeoutHandle)
+      resolve()
+    })
+  })
+}
+
+export function promisify (original) {
+  return function (...args) {
+    return new Promise((resolve, reject) => {
+      args.push((err, ...results) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(...results)
+        }
+      })
+
+      return original(...args)
+    })
+  }
+}
+
+export function promisifySome (obj, fnNames) {
+  const result = {}
+  for (const fnName of fnNames) {
+    result[fnName] = promisify(obj[fnName])
+  }
+  return result
+}

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -1,0 +1,14 @@
+module.exports = {
+  getWrapGuides () {
+    wrapGuides = []
+    for (const editor of atom.workspace.getTextEditors()) {
+      const guide = editor.getElement().querySelector('.wrap-guide')
+      if (guide) wrapGuides.push(guide)
+    }
+    return wrapGuides
+  },
+
+  getLeftPosition (element) {
+    return parseInt(element.style.left)
+  }
+}

--- a/spec/wrap-guide-element-spec.coffee
+++ b/spec/wrap-guide-element-spec.coffee
@@ -1,8 +1,7 @@
-describe "WrapGuide", ->
-  [editor, editorElement, wrapGuide, workspaceElement] = []
+{getLeftPosition} = require './helpers'
 
-  getLeftPosition = (element) ->
-    parseInt(element.style.left)
+describe "WrapGuideElement", ->
+  [editor, editorElement, wrapGuide, workspaceElement] = []
 
   beforeEach ->
     workspaceElement = atom.views.getView(atom.workspace)
@@ -27,31 +26,6 @@ describe "WrapGuide", ->
       editor = atom.workspace.getActiveTextEditor()
       editorElement = editor.getElement()
       wrapGuide = editorElement.querySelector(".wrap-guide")
-
-  describe ".activate", ->
-    getWrapGuides  = ->
-      wrapGuides = []
-      atom.workspace.getTextEditors().forEach (editor) ->
-        guide = editor.getElement().querySelector(".wrap-guide")
-        wrapGuides.push(guide) if guide
-      wrapGuides
-
-    it "appends a wrap guide to all existing and new editors", ->
-      expect(atom.workspace.getTextEditors().length).toBe 1
-      expect(getWrapGuides().length).toBe 1
-      expect(getLeftPosition(getWrapGuides()[0])).toBeGreaterThan(0)
-
-      atom.workspace.getActivePane().splitRight(copyActiveItem: true)
-      expect(atom.workspace.getTextEditors().length).toBe 2
-      expect(getWrapGuides().length).toBe 2
-      expect(getLeftPosition(getWrapGuides()[0])).toBeGreaterThan(0)
-      expect(getLeftPosition(getWrapGuides()[1])).toBeGreaterThan(0)
-
-    it "positions the guide at the configured column", ->
-      width = editor.getDefaultCharWidth() * wrapGuide.getDefaultColumn()
-      expect(width).toBeGreaterThan(0)
-      expect(Math.abs(getLeftPosition(wrapGuide) - width)).toBeLessThan 1
-      expect(wrapGuide).toBeVisible()
 
   describe "when the font size changes", ->
     it "updates the wrap guide position", ->

--- a/spec/wrap-guide-spec.js
+++ b/spec/wrap-guide-spec.js
@@ -1,0 +1,48 @@
+const {getWrapGuides, getLeftPosition} = require('./helpers')
+
+const {it, fit, ffit, afterEach, beforeEach} = require('./async-spec-helpers') // eslint-disable-line no-unused-vars
+
+describe('Wrap Guide', () => {
+  let editor, editorElement, wrapGuide = []
+
+  beforeEach(async () => {
+    await atom.packages.activatePackage('wrap-guide')
+
+    editor = await atom.workspace.open('sample.js')
+    editorElement = editor.getElement()
+    wrapGuide = editorElement.querySelector('.wrap-guide')
+
+    jasmine.attachToDOM(atom.views.getView(atom.workspace))
+  })
+
+  describe('package activation', () => {
+    it('appends a wrap guide to all existing and new editors', () => {
+      expect(atom.workspace.getTextEditors().length).toBe(1)
+      expect(getWrapGuides().length).toBe(1)
+      expect(getLeftPosition(getWrapGuides()[0])).toBeGreaterThan(0)
+
+      atom.workspace.getActivePane().splitRight({copyActiveItem: true})
+      expect(atom.workspace.getTextEditors().length).toBe(2)
+      expect(getWrapGuides().length).toBe(2)
+      expect(getLeftPosition(getWrapGuides()[0])).toBeGreaterThan(0)
+      expect(getLeftPosition(getWrapGuides()[1])).toBeGreaterThan(0)
+    })
+
+    it('positions the guide at the configured column', () => {
+      width = editor.getDefaultCharWidth() * wrapGuide.getDefaultColumn()
+      expect(width).toBeGreaterThan(0)
+      expect(Math.abs(getLeftPosition(wrapGuide) - width)).toBeLessThan(1)
+      expect(wrapGuide).toBeVisible()
+    })
+  })
+
+  describe('package deactivation', () => {
+    beforeEach(async () => {
+      await atom.packages.deactivatePackage('wrap-guide')
+    })
+
+    it('disposes of all wrap guides', () => {
+      expect(getWrapGuides().length).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

When deactivating, dispose of all subscriptions and remove wrap guide elements from the editor.  Previously the only reason why the wrap guide "disappeared" was because its styling was removed - if you had some custom styling for it in your theme or `styles.less` there was a good chance it would continue to show up even after disabling wrap-guide as the element itself was still present in the DOM.

These changes necessitated converting the editor WeakSet introduced in #71 to an editor -> wrap guide Map.

### Alternate Designs

I don't see any alternatives.

### Benefits

Proper package deactivation.

### Possible Drawbacks

I'd like to say none.  I'm still a bit fuzzy on the Map/WeakMap difference but it seems appropriate here to use a Map for the iteration on deactivate.  There also shouldn't be a case where the only editor reference is contained in the Map.

### Applicable Issues

None.