### PR TITLE
Wait for update promise after changing font size before updating guide

### DIFF
--- a/lib/wrap-guide-element.coffee
+++ b/lib/wrap-guide-element.coffee
@@ -24,15 +24,15 @@ class WrapGuideElement
 
     @handleConfigEvents()
 
-    @subscriptions.add atom.config.onDidChange 'editor.fontSize', ->
-      # setTimeout because we need to wait for the editor measurement to happen
-      setTimeout(updateGuideCallback, 0)
+    @subscriptions.add atom.config.onDidChange 'editor.fontSize', =>
+      # TODO: Use async/await once this file is converted to JS
+      @editorElement.getComponent().getNextUpdatePromise().then -> updateGuideCallback()
 
     @subscriptions.add @editorElement.onDidChangeScrollLeft(updateGuideCallback)
     @subscriptions.add @editor.onDidChangePath(updateGuideCallback)
     @subscriptions.add @editor.onDidChangeGrammar =>
       @configSubscriptions.dispose()
-      @configSubscriptions = @handleConfigEvents()
+      @handleConfigEvents()
       updateGuideCallback()
 
     @subscriptions.add @editor.onDidDestroy =>

--- a/lib/wrap-guide-element.coffee
+++ b/lib/wrap-guide-element.coffee
@@ -25,6 +25,7 @@ class WrapGuideElement
     @handleConfigEvents()
 
     @subscriptions.add atom.config.onDidChange 'editor.fontSize', =>
+      # Wait for editor to finish updating before updating wrap guide
       # TODO: Use async/await once this file is converted to JS
       @editorElement.getComponent().getNextUpdatePromise().then -> updateGuideCallback()
 

--- a/spec/wrap-guide-element-spec.coffee
+++ b/spec/wrap-guide-element-spec.coffee
@@ -34,9 +34,31 @@ describe "WrapGuideElement", ->
       fontSize = atom.config.get("editor.fontSize")
       atom.config.set("editor.fontSize", fontSize + 10)
 
-      advanceClock(1)
-      expect(getLeftPosition(wrapGuide)).toBeGreaterThan(initial)
-      expect(wrapGuide).toBeVisible()
+      waitsForPromise ->
+        editorElement.getComponent().getNextUpdatePromise()
+
+      runs ->
+        expect(getLeftPosition(wrapGuide)).toBeGreaterThan(initial)
+        expect(wrapGuide).toBeVisible()
+
+    it "updates the wrap guide position for hidden editors", ->
+      initial = getLeftPosition(wrapGuide)
+      expect(initial).toBeGreaterThan(0)
+
+      waitsForPromise ->
+        atom.workspace.open()
+
+      runs ->
+        fontSize = atom.config.get("editor.fontSize")
+        atom.config.set("editor.fontSize", fontSize + 10)
+        atom.workspace.getActivePane().activatePreviousItem()
+
+        waitsForPromise ->
+          editorElement.getComponent().getNextUpdatePromise()
+
+        runs ->
+          expect(getLeftPosition(wrapGuide)).toBeGreaterThan(initial)
+          expect(wrapGuide).toBeVisible()
 
   describe "when the column config changes", ->
     it "updates the wrap guide position", ->

--- a/spec/wrap-guide-element-spec.coffee
+++ b/spec/wrap-guide-element-spec.coffee
@@ -41,7 +41,7 @@ describe "WrapGuideElement", ->
         expect(getLeftPosition(wrapGuide)).toBeGreaterThan(initial)
         expect(wrapGuide).toBeVisible()
 
-    it "updates the wrap guide position for hidden editors", ->
+    it "updates the wrap guide position for hidden editors when they become visible", ->
       initial = getLeftPosition(wrapGuide)
       expect(initial).toBeGreaterThan(0)
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

By waiting for the editor update promise, we ensure that we are calculating the wrap guide position based on up-to-date editor measurements.  This is particularly relevant for editors in the background, as those aren't updated until they become focused.

Also fixes a regression from #76.

### Alternate Designs

None.

### Benefits

Wrap guide changes position correctly after changing font size.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #25